### PR TITLE
♻️ Refactor socket io handling

### DIFF
--- a/ioc_module.js
+++ b/ioc_module.js
@@ -13,7 +13,7 @@ const socketEndpointDiscoveryTag = require('@essential-projects/bootstrapper_con
 function registerInContainer(container) {
 
   container.register('ManagementApiCorrelationRouter', CorrelationEndpoint.CorrelationRouter)
-    .dependencies('ManagementApiCorrelationController')
+    .dependencies('ManagementApiCorrelationController', 'IdentityService')
     .singleton()
     .tags(routerDiscoveryTag);
 
@@ -22,7 +22,7 @@ function registerInContainer(container) {
     .singleton();
 
   container.register('ManagementApiEventRouter', EventEndpoint.EventRouter)
-    .dependencies('ManagementApiEventController')
+    .dependencies('ManagementApiEventController', 'IdentityService')
     .singleton()
     .tags(routerDiscoveryTag);
 
@@ -31,7 +31,7 @@ function registerInContainer(container) {
     .singleton();
 
   container.register('ManagementApiHeatmapRouter', HeatmapEndpoint.HeatmapRouter)
-    .dependencies('ManagementApiHeatmapController')
+    .dependencies('ManagementApiHeatmapController', 'IdentityService')
     .singleton()
     .tags(routerDiscoveryTag);
 
@@ -40,7 +40,7 @@ function registerInContainer(container) {
     .singleton();
 
   container.register('ManagementApiProcessModelRouter', ProcessModelsEndpoint.ProcessModelRouter)
-    .dependencies('ManagementApiProcessModelController')
+    .dependencies('ManagementApiProcessModelController', 'IdentityService')
     .singleton()
     .tags(routerDiscoveryTag);
 
@@ -54,7 +54,7 @@ function registerInContainer(container) {
     .singleton();
 
   container.register('ManagementApiUserTaskRouter', UserTasksEndpoint.UserTaskRouter)
-    .dependencies('ManagementApiUserTaskController')
+    .dependencies('ManagementApiUserTaskController', 'IdentityService')
     .singleton()
     .tags(routerDiscoveryTag);
 
@@ -68,7 +68,7 @@ function registerInContainer(container) {
     .tags(socketEndpointDiscoveryTag);
 
   container.register('ManagementApiManualTaskRouter', ManualTasksEndpoint.ManualTaskRouter)
-    .dependencies('ManagementApiManualTaskController')
+    .dependencies('ManagementApiManualTaskController', 'IdentityService')
     .singleton()
     .tags(routerDiscoveryTag);
 

--- a/ioc_module.js
+++ b/ioc_module.js
@@ -45,7 +45,7 @@ function registerInContainer(container) {
     .tags(routerDiscoveryTag);
 
   container.register('ManagementApiProcessModelSocketEndpoint', ProcessModelsEndpoint.ProcessModelSocketEndpoint)
-    .dependencies('EventAggregator')
+    .dependencies('EventAggregator', 'IdentityService', 'ManagementApiService')
     .singleton()
     .tags(socketEndpointDiscoveryTag);
 
@@ -63,7 +63,7 @@ function registerInContainer(container) {
     .singleton();
 
   container.register('ManagementApiUserTaskSocketEndpoint', UserTasksEndpoint.UserTaskSocketEndpoint)
-    .dependencies('EventAggregator')
+    .dependencies('EventAggregator', 'IdentityService', 'ManagementApiService')
     .singleton()
     .tags(socketEndpointDiscoveryTag);
 
@@ -77,7 +77,7 @@ function registerInContainer(container) {
     .singleton();
 
   container.register('ManagementApiManualTaskSocketEndpoint', ManualTasksEndpoint.ManualTaskSocketEndpoint)
-    .dependencies('EventAggregator')
+    .dependencies('EventAggregator', 'IdentityService', 'ManagementApiService')
     .singleton()
     .tags(socketEndpointDiscoveryTag);
 }

--- a/ioc_module.js
+++ b/ioc_module.js
@@ -45,7 +45,7 @@ function registerInContainer(container) {
     .tags(routerDiscoveryTag);
 
   container.register('ManagementApiProcessModelSocketEndpoint', ProcessModelsEndpoint.ProcessModelSocketEndpoint)
-    .dependencies('EventAggregator', 'IdentityService', 'ManagementApiService')
+    .dependencies('EventAggregator', 'IdentityService')
     .singleton()
     .tags(socketEndpointDiscoveryTag);
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@essential-projects/errors_ts": "~1.4.0",
     "@essential-projects/http_contracts": "~2.3.0",
     "@essential-projects/http_node": "~4.1.0",
-    "@essential-projects/iam_contracts": "feature~refactor_socket_io_handling",
+    "@essential-projects/iam_contracts": "~3.4.0",
     "@process-engine/management_api_contracts": "feature~refactor_socket_io_handling",
     "async-middleware": "~1.2.1",
     "socket.io": "~2.2.0"

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
     "@essential-projects/errors_ts": "~1.4.0",
     "@essential-projects/http_contracts": "~2.3.0",
     "@essential-projects/http_node": "~4.1.0",
-    "@essential-projects/iam_contracts": "~3.3.0",
-    "@process-engine/management_api_contracts": "~3.0.0",
+    "@essential-projects/iam_contracts": "feature~refactor_socket_io_handling",
+    "@process-engine/management_api_contracts": "feature~refactor_socket_io_handling",
     "async-middleware": "~1.2.1",
     "socket.io": "~2.2.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/management_api_http",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "HTTP endpoint implementation for the process-engine.io Management APIs",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@essential-projects/http_contracts": "~2.3.0",
     "@essential-projects/http_node": "~4.1.0",
     "@essential-projects/iam_contracts": "~3.4.0",
-    "@process-engine/management_api_contracts": "feature~refactor_socket_io_handling",
+    "@process-engine/management_api_contracts": "~4.0.0",
     "async-middleware": "~1.2.1",
     "socket.io": "~2.2.0"
   },

--- a/src/endpoints/heatmap/heatmap_router.ts
+++ b/src/endpoints/heatmap/heatmap_router.ts
@@ -1,22 +1,22 @@
 import {BaseRouter} from '@essential-projects/http_node';
+import {IIdentityService} from '@essential-projects/iam_contracts';
+
 import {restSettings} from '@process-engine/management_api_contracts';
 
-import {resolveIdentity} from './../../middlewares/resolve_identity';
+import {createResolveIdentityMiddleware, MiddlewareFunction} from './../../middlewares/resolve_identity';
 import {HeatmapController} from './heatmap_controller';
 
 import {wrap} from 'async-middleware';
 
 export class HeatmapRouter extends BaseRouter {
 
+  private _identityService: IIdentityService;
   private _heatmapController: HeatmapController;
 
-  constructor(heatmapController: HeatmapController) {
+  constructor(heatmapController: HeatmapController, identityService: IIdentityService) {
     super();
     this._heatmapController = heatmapController;
-  }
-
-  private get heatmapController(): HeatmapController {
-    return this._heatmapController;
+    this._identityService = identityService;
   }
 
   public get baseRoute(): string {
@@ -29,11 +29,12 @@ export class HeatmapRouter extends BaseRouter {
   }
 
   private registerMiddlewares(): void {
+    const resolveIdentity: MiddlewareFunction = createResolveIdentityMiddleware(this._identityService);
     this.router.use(wrap(resolveIdentity));
   }
 
   private registerRoutes(): void {
-    const controller: HeatmapController = this.heatmapController;
+    const controller: HeatmapController = this._heatmapController;
 
     this.router.get(restSettings.paths.getRuntimeInformationForProcessModel, wrap(controller.getRuntimeInformationForProcessModel.bind(controller)));
     this.router.get(restSettings.paths.getActiveTokensForProcessModel, wrap(controller.getActiveTokensForProcessModel.bind(controller)));

--- a/src/endpoints/manual_tasks/manual_task_router.ts
+++ b/src/endpoints/manual_tasks/manual_task_router.ts
@@ -1,22 +1,22 @@
 import {BaseRouter} from '@essential-projects/http_node';
+import {IIdentityService} from '@essential-projects/iam_contracts';
+
 import {restSettings} from '@process-engine/management_api_contracts';
 
-import {resolveIdentity} from '../../middlewares/resolve_identity';
+import {createResolveIdentityMiddleware, MiddlewareFunction} from './../../middlewares/resolve_identity';
 import {ManualTaskController} from './manual_task_controller';
 
 import {wrap} from 'async-middleware';
 
 export class ManualTaskRouter extends BaseRouter {
 
+  private _identityService: IIdentityService;
   private _manualTaskController: ManualTaskController;
 
-  constructor(manualTaskController: ManualTaskController) {
+  constructor(manualTaskController: ManualTaskController, identityService: IIdentityService) {
     super();
     this._manualTaskController = manualTaskController;
-  }
-
-  private get manualTaskController(): ManualTaskController {
-    return this._manualTaskController;
+    this._identityService = identityService;
   }
 
   public get baseRoute(): string {
@@ -29,11 +29,12 @@ export class ManualTaskRouter extends BaseRouter {
   }
 
   private registerMiddlewares(): void {
+    const resolveIdentity: MiddlewareFunction = createResolveIdentityMiddleware(this._identityService);
     this.router.use(wrap(resolveIdentity));
   }
 
   private registerRoutes(): void {
-    const controller: ManualTaskController = this.manualTaskController;
+    const controller: ManualTaskController = this._manualTaskController;
 
     this.router.get(restSettings.paths.processModelManualTasks, wrap(controller.getManualTasksForProcessModel.bind(controller)));
     this.router.get(restSettings.paths.correlationManualTasks, wrap(controller.getManualTasksForCorrelation.bind(controller)));

--- a/src/endpoints/manual_tasks/manual_task_socket_endpoint.ts
+++ b/src/endpoints/manual_tasks/manual_task_socket_endpoint.ts
@@ -1,24 +1,32 @@
 import {Logger} from 'loggerhythm';
 
-import {IEventAggregator} from '@essential-projects/event_aggregator_contracts';
+import {UnauthorizedError} from '@essential-projects/errors_ts';
+import {IEventAggregator, Subscription} from '@essential-projects/event_aggregator_contracts';
 import {BaseSocketEndpoint} from '@essential-projects/http_node';
+import {IIdentity, IIdentityService} from '@essential-projects/iam_contracts';
 
-import {Messages, socketSettings} from '@process-engine/management_api_contracts';
+import {IManagementApi, Messages, socketSettings} from '@process-engine/management_api_contracts';
 
 const logger: Logger = Logger.createLogger('management_api:socket.io_endpoint:user_tasks');
 
-interface IConnection {
-  identity: string;
-}
+type UserSubscriptionDictionary = {[userId: string]: Array<Subscription>};
 
 export class ManualTaskSocketEndpoint extends BaseSocketEndpoint {
 
-  private _connections: Map<string, IConnection> = new Map();
-  private _eventAggregator: IEventAggregator;
+  private _connections: Map<string, IIdentity> = new Map();
 
-  constructor(eventAggregator: IEventAggregator) {
+  private _managementApiService: IManagementApi;
+  private _eventAggregator: IEventAggregator;
+  private _identityService: IIdentityService;
+
+  private _endpointSubscriptions: Array<Subscription> = [];
+  private _userSubscriptions: UserSubscriptionDictionary = {};
+
+  constructor(eventAggregator: IEventAggregator, identityService: IIdentityService, managementApiService: IManagementApi) {
     super();
     this._eventAggregator = eventAggregator;
+    this._identityService = identityService;
+    this._managementApiService = managementApiService;
   }
 
   public get namespace(): string {
@@ -27,14 +35,19 @@ export class ManualTaskSocketEndpoint extends BaseSocketEndpoint {
 
   public initializeEndpoint(socketIo: SocketIO.Namespace): void {
 
-    socketIo.on('connect', (socket: SocketIO.Socket) => {
-      const identity: string = socket.handshake.headers['authorization'];
+    socketIo.on('connect', async(socket: SocketIO.Socket) => {
+      const token: string = socket.handshake.headers['authorization'];
 
-      const connection: IConnection = {
-        identity,
-      };
+      const identityNotSet: boolean = token === undefined;
+      if (identityNotSet) {
+        logger.error('A Socket.IO client attempted to connect without providing an Auth-Token!');
+        socket.disconnect();
+        throw new UnauthorizedError('No auth token provided!');
+      }
 
-      this._connections.set(socket.id, connection);
+      const identity: IIdentity = await this._identityService.getIdentity(token);
+
+      this._connections.set(socket.id, identity);
 
       logger.info(`Client with socket id "${socket.id} connected."`);
 

--- a/src/endpoints/manual_tasks/manual_task_socket_endpoint.ts
+++ b/src/endpoints/manual_tasks/manual_task_socket_endpoint.ts
@@ -51,8 +51,10 @@ export class ManualTaskSocketEndpoint extends BaseSocketEndpoint {
 
       logger.info(`Client with socket id "${socket.id} connected."`);
 
-      socket.on('disconnect', (reason: any) => {
+      socket.on('disconnect', async(reason: any) => {
         this._connections.delete(socket.id);
+
+        await this._clearUserScopeNotifications(identity);
 
         logger.info(`Client with socket id "${socket.id} disconnected."`);
       });
@@ -61,6 +63,26 @@ export class ManualTaskSocketEndpoint extends BaseSocketEndpoint {
     });
 
     await this._createSocketScopeNotifications(socketIo);
+  }
+
+  public async dispose(): Promise<void> {
+
+    logger.info(`Disposing Socket IO subscriptions...`);
+    // Clear out Socket-scope Subscriptions.
+    for (const subscription of this._endpointSubscriptions) {
+      this._eventAggregator.unsubscribe(subscription);
+    }
+
+    // Clear out all User-Subscriptions.
+    for (const userId in this._userSubscriptions) {
+      const userSubscriptions: Array<Subscription> = this._userSubscriptions[userId];
+
+      for (const subscription of userSubscriptions) {
+        this._eventAggregator.unsubscribe(subscription);
+      }
+
+      delete this._userSubscriptions[userId];
+    }
   }
 
   /**
@@ -127,5 +149,31 @@ export class ManualTaskSocketEndpoint extends BaseSocketEndpoint {
     userSubscriptions.push(onManualTaskForIdentityFinishedSubscription);
 
     this._userSubscriptions[identity.userId] = userSubscriptions;
+  }
+
+  /**
+   * Clears out all Subscriptions for the given identity.
+   * Should only be used when a client disconnects.
+   *
+   * @async
+   * @param identity The identity for which to remove the Subscriptions.
+   */
+  private async _clearUserScopeNotifications(identity: IIdentity): Promise<void> {
+
+    logger.verbose(`Clearing subscriptions for user with ID ${identity.userId}`);
+    const userSubscriptions: Array<Subscription> = this._userSubscriptions[identity.userId];
+
+    const noSubscriptionsFound: boolean = !userSubscriptions;
+    if (noSubscriptionsFound) {
+      logger.verbose(`No subscriptions for user with ID ${identity.userId} found.`);
+
+      return;
+    }
+
+    for (const subscription of userSubscriptions) {
+      await this._managementApiService.removeSubscription(identity, subscription);
+    }
+
+    delete this._userSubscriptions[identity.userId];
   }
 }

--- a/src/endpoints/process_models/process_model_router.ts
+++ b/src/endpoints/process_models/process_model_router.ts
@@ -1,22 +1,22 @@
 import {BaseRouter} from '@essential-projects/http_node';
+import {IIdentityService} from '@essential-projects/iam_contracts';
+
 import {restSettings} from '@process-engine/management_api_contracts';
 
-import {resolveIdentity} from './../../middlewares/resolve_identity';
+import {createResolveIdentityMiddleware, MiddlewareFunction} from './../../middlewares/resolve_identity';
 import {ProcessModelController} from './process_model_controller';
 
 import {wrap} from 'async-middleware';
 
 export class ProcessModelRouter extends BaseRouter {
 
+  private _identityService: IIdentityService;
   private _processModelController: ProcessModelController;
 
-  constructor(processModelController: ProcessModelController) {
+  constructor(processModelController: ProcessModelController, identityService: IIdentityService) {
     super();
     this._processModelController = processModelController;
-  }
-
-  private get processModelController(): ProcessModelController {
-    return this._processModelController;
+    this._identityService = identityService;
   }
 
   public get baseRoute(): string {
@@ -29,11 +29,12 @@ export class ProcessModelRouter extends BaseRouter {
   }
 
   private registerMiddlewares(): void {
+    const resolveIdentity: MiddlewareFunction = createResolveIdentityMiddleware(this._identityService);
     this.router.use(wrap(resolveIdentity));
   }
 
   private registerRoutes(): void {
-    const controller: ProcessModelController = this.processModelController;
+    const controller: ProcessModelController = this._processModelController;
 
     this.router.get(restSettings.paths.processModels, wrap(controller.getProcessModels.bind(controller)));
     this.router.get(restSettings.paths.processModelById, wrap(controller.getProcessModelById.bind(controller)));

--- a/src/endpoints/process_models/process_model_socket_endpoint.ts
+++ b/src/endpoints/process_models/process_model_socket_endpoint.ts
@@ -55,6 +55,13 @@ export class ProcessModelSocketEndpoint extends BaseSocketEndpoint {
     await this._createSocketScopeNotifications(socketIo);
   }
 
+  public async dispose(): Promise<void> {
+    logger.info(`Disposing Socket IO subscriptions...`);
+    for (const subscription of this._endpointSubscriptions) {
+      this._eventAggregator.unsubscribe(subscription);
+    }
+  }
+
   /**
    * Creates a number of Subscriptions for globally published events.
    * These events will be published for every user connected to the socketIO
@@ -94,5 +101,4 @@ export class ProcessModelSocketEndpoint extends BaseSocketEndpoint {
     this._endpointSubscriptions.push(processEndedSubscription);
     this._endpointSubscriptions.push(processTerminatedSubscription);
   }
-
 }

--- a/src/endpoints/process_models/process_model_socket_endpoint.ts
+++ b/src/endpoints/process_models/process_model_socket_endpoint.ts
@@ -1,24 +1,32 @@
 import {Logger} from 'loggerhythm';
 
 import {UnauthorizedError} from '@essential-projects/errors_ts';
-import {IEventAggregator} from '@essential-projects/event_aggregator_contracts';
+import {IEventAggregator, Subscription} from '@essential-projects/event_aggregator_contracts';
 import {BaseSocketEndpoint} from '@essential-projects/http_node';
-import {Messages, socketSettings} from '@process-engine/management_api_contracts';
+import {IIdentity, IIdentityService} from '@essential-projects/iam_contracts';
 
-const logger: Logger = Logger.createLogger('management_api:socket.io_endpoint:process_models');
+import {IManagementApi, Messages, socketSettings} from '@process-engine/management_api_contracts';
 
-interface IConnection {
-  identity: string;
-}
+const logger: Logger = Logger.createLogger('management_api:socket.io_endpoint:user_tasks');
+
+type UserSubscriptionDictionary = {[userId: string]: Array<Subscription>};
 
 export class ProcessModelSocketEndpoint extends BaseSocketEndpoint {
 
-  private _connections: Map<string, IConnection> = new Map();
-  private _eventAggregator: IEventAggregator;
+  private _connections: Map<string, IIdentity> = new Map();
 
-  constructor(eventAggregator: IEventAggregator) {
+  private _managementApiService: IManagementApi;
+  private _eventAggregator: IEventAggregator;
+  private _identityService: IIdentityService;
+
+  private _endpointSubscriptions: Array<Subscription> = [];
+  private _userSubscriptions: UserSubscriptionDictionary = {};
+
+  constructor(eventAggregator: IEventAggregator, identityService: IIdentityService, managementApiService: IManagementApi) {
     super();
     this._eventAggregator = eventAggregator;
+    this._identityService = identityService;
+    this._managementApiService = managementApiService;
   }
 
   public get namespace(): string {
@@ -27,19 +35,19 @@ export class ProcessModelSocketEndpoint extends BaseSocketEndpoint {
 
   public initializeEndpoint(socketIo: SocketIO.Namespace): void {
 
-    socketIo.on('connect', (socket: SocketIO.Socket) => {
-      const identity: string = socket.handshake.headers['authorization'];
+    socketIo.on('connect', async(socket: SocketIO.Socket) => {
+      const token: string = socket.handshake.headers['authorization'];
 
-      const connection: IConnection = {
-        identity,
-      };
-
-      const identityNotSet: boolean = identity === undefined;
+      const identityNotSet: boolean = token === undefined;
       if (identityNotSet) {
+        logger.error('A Socket.IO client attempted to connect without providing an Auth-Token!');
+        socket.disconnect();
         throw new UnauthorizedError('No auth token provided!');
       }
 
-      this._connections.set(socket.id, connection);
+      const identity: IIdentity = await this._identityService.getIdentity(token);
+
+      this._connections.set(socket.id, identity);
 
       logger.info(`Client with socket id "${socket.id} connected."`);
 

--- a/src/endpoints/user_tasks/user_task_router.ts
+++ b/src/endpoints/user_tasks/user_task_router.ts
@@ -1,22 +1,22 @@
 import {BaseRouter} from '@essential-projects/http_node';
+import {IIdentityService} from '@essential-projects/iam_contracts';
+
 import {restSettings} from '@process-engine/management_api_contracts';
 
-import {resolveIdentity} from './../../middlewares/resolve_identity';
+import {createResolveIdentityMiddleware, MiddlewareFunction} from './../../middlewares/resolve_identity';
 import {UserTaskController} from './user_task_controller';
 
 import {wrap} from 'async-middleware';
 
 export class UserTaskRouter extends BaseRouter {
 
+  private _identityService: IIdentityService;
   private _userTaskController: UserTaskController;
 
-  constructor(userTaskController: UserTaskController) {
+  constructor(userTaskController: UserTaskController, identityService: IIdentityService) {
     super();
     this._userTaskController = userTaskController;
-  }
-
-  private get userTaskController(): UserTaskController {
-    return this._userTaskController;
+    this._identityService = identityService;
   }
 
   public get baseRoute(): string {
@@ -29,11 +29,12 @@ export class UserTaskRouter extends BaseRouter {
   }
 
   private registerMiddlewares(): void {
+    const resolveIdentity: MiddlewareFunction = createResolveIdentityMiddleware(this._identityService);
     this.router.use(wrap(resolveIdentity));
   }
 
   private registerRoutes(): void {
-    const controller: UserTaskController = this.userTaskController;
+    const controller: UserTaskController = this._userTaskController;
 
     this.router.get(restSettings.paths.processModelUserTasks, wrap(controller.getUserTasksForProcessModel.bind(controller)));
     this.router.get(restSettings.paths.correlationUserTasks, wrap(controller.getUserTasksForCorrelation.bind(controller)));

--- a/src/endpoints/user_tasks/user_task_socket_endpoint.ts
+++ b/src/endpoints/user_tasks/user_task_socket_endpoint.ts
@@ -1,25 +1,32 @@
 import {Logger} from 'loggerhythm';
 
 import {UnauthorizedError} from '@essential-projects/errors_ts';
-import {IEventAggregator} from '@essential-projects/event_aggregator_contracts';
+import {IEventAggregator, Subscription} from '@essential-projects/event_aggregator_contracts';
 import {BaseSocketEndpoint} from '@essential-projects/http_node';
+import {IIdentity, IIdentityService} from '@essential-projects/iam_contracts';
 
-import {Messages, socketSettings} from '@process-engine/management_api_contracts';
+import {IManagementApi, Messages, socketSettings} from '@process-engine/management_api_contracts';
 
 const logger: Logger = Logger.createLogger('management_api:socket.io_endpoint:user_tasks');
 
-interface IConnection {
-  identity: string;
-}
+type UserSubscriptionDictionary = {[userId: string]: Array<Subscription>};
 
 export class UserTaskSocketEndpoint extends BaseSocketEndpoint {
 
-  private _connections: Map<string, IConnection> = new Map();
-  private _eventAggregator: IEventAggregator;
+  private _connections: Map<string, IIdentity> = new Map();
 
-  constructor(eventAggregator: IEventAggregator) {
+  private _managementApiService: IManagementApi;
+  private _eventAggregator: IEventAggregator;
+  private _identityService: IIdentityService;
+
+  private _endpointSubscriptions: Array<Subscription> = [];
+  private _userSubscriptions: UserSubscriptionDictionary = {};
+
+  constructor(eventAggregator: IEventAggregator, identityService: IIdentityService, managementApiService: IManagementApi) {
     super();
     this._eventAggregator = eventAggregator;
+    this._identityService = identityService;
+    this._managementApiService = managementApiService;
   }
 
   public get namespace(): string {
@@ -28,19 +35,19 @@ export class UserTaskSocketEndpoint extends BaseSocketEndpoint {
 
   public initializeEndpoint(socketIo: SocketIO.Namespace): void {
 
-    socketIo.on('connect', (socket: SocketIO.Socket) => {
-      const identity: string = socket.handshake.headers['authorization'];
+    socketIo.on('connect', async(socket: SocketIO.Socket) => {
+      const token: string = socket.handshake.headers['authorization'];
 
-      const connection: IConnection = {
-        identity,
-      };
-
-      const identityNotSet: boolean = identity === undefined;
+      const identityNotSet: boolean = token === undefined;
       if (identityNotSet) {
+        logger.error('A Socket.IO client attempted to connect without providing an Auth-Token!');
+        socket.disconnect();
         throw new UnauthorizedError('No auth token provided!');
       }
 
-      this._connections.set(socket.id, connection);
+      const identity: IIdentity = await this._identityService.getIdentity(token);
+
+      this._connections.set(socket.id, identity);
 
       logger.info(`Client with socket id "${socket.id} connected."`);
 


### PR DESCRIPTION
**Changes:**

1. Use the IdentityService to create Identities. This avoids the need to manually decode a requesting users token, in order to get the associated userId.
2. Implement Socket.IO endpoint disposal:
    - When a client disconnects, the subscriptions created specifically for that client will get removed from the event aggregator.
    - When the endpoint itself is disposed, all socket.IO clients get disconnected and all subscriptions created by the endpoint will be removed.
3. Remove the redundant `IConnection` type.
4. Create an internal Subscription storage that keeps track of all Subscriptions. The storage is split into two scopes:
    - Endpoint-Scope: Stores all global subscriptions that are used commonly for all clients.
    - Client-Scope: Stores all subscriptions for the individual clients. 
5. Add identity-specific Notifications for UserTasks and ManualTasks.

**Issues:**

Part of https://github.com/process-engine/process_engine_runtime/issues/#135
Part of https://github.com/process-engine/process_engine_runtime/issues/#157
Part of https://github.com/process-engine/process_engine_runtime/issues/#206

PR: #31

## How can others test the changes?

- Connect a client.
- Trigger some notifications for that client.
- Disconnect the client.
- Trigger the same notifications again.
- Notice that the corresponding subscriptions are no longer active.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.).
- [x] I've rebased the `develop` branch with my branch before finishing this PR.
- [x] I've **summarized all changes** in a list above.
- [x] I've mentioned all **PRs, which relate to this one**.
- [x] I've prefixed my Pull Request title is according to [gitmoji guide](https://gitmoji.carloscuesta.me/).