### PR TITLE
♻️ Make the StartEventId Parameter Optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@essential-projects/http_contracts": "^2.3.0",
     "@essential-projects/http_node": "^4.1.0",
     "@essential-projects/iam_contracts": "^3.4.0",
-    "@process-engine/management_api_contracts": "^4.2.0",
+    "@process-engine/management_api_contracts": "feature~optional_start_event_id",
     "async-middleware": "^1.2.1",
     "socket.io": "^2.2.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/management_api_http",
-  "version": "3.1.3",
+  "version": "4.0.0",
   "description": "HTTP endpoint implementation for the process-engine.io Management APIs",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@essential-projects/http_contracts": "^2.3.0",
     "@essential-projects/http_node": "^4.1.0",
     "@essential-projects/iam_contracts": "^3.4.0",
-    "@process-engine/management_api_contracts": "feature~optional_start_event_id",
+    "@process-engine/management_api_contracts": "^5.0.0",
     "async-middleware": "^1.2.1",
     "socket.io": "^2.2.0"
   },

--- a/src/endpoints/process_models/process_model_controller.ts
+++ b/src/endpoints/process_models/process_model_controller.ts
@@ -71,7 +71,7 @@ export class ProcessModelController {
     const identity: IIdentity = request.identity;
 
     const result: DataModels.ProcessModels.ProcessStartResponsePayload =
-      await this.managementApiService.startProcessInstance(identity, processModelId, startEventId, payload, startCallbackType, endEventId);
+      await this.managementApiService.startProcessInstance(identity, processModelId, payload, startCallbackType, startEventId, endEventId);
 
     response.status(this.httpCodeSuccessfulResponse).json(result);
   }

--- a/src/endpoints/process_models/process_model_controller.ts
+++ b/src/endpoints/process_models/process_model_controller.ts
@@ -58,8 +58,8 @@ export class ProcessModelController {
 
   public async startProcessInstance(request: HttpRequestWithIdentity, response: Response): Promise<void> {
     const processModelId: string = request.params.process_model_id;
-    const startEventId: string = request.query[restSettings.queryParams.startEventId];
-    const endEventId: string = request.query[restSettings.queryParams.endEventId];
+    const startEventId: string = request.query.start_event_id;
+    const endEventId: string = request.query.end_event_id;
     const payload: DataModels.ProcessModels.ProcessStartRequestPayload = request.body;
     let startCallbackType: DataModels.ProcessModels.StartCallbackType =
       <DataModels.ProcessModels.StartCallbackType> Number.parseInt(request.query.start_callback_type);

--- a/src/endpoints/process_models/process_model_controller.ts
+++ b/src/endpoints/process_models/process_model_controller.ts
@@ -58,7 +58,7 @@ export class ProcessModelController {
 
   public async startProcessInstance(request: HttpRequestWithIdentity, response: Response): Promise<void> {
     const processModelId: string = request.params.process_model_id;
-    const startEventId: string = request.params.start_event_id;
+    const startEventId: string = request.query.start_event_id[restSettings.queryParams.startEventId];
     const endEventId: string = request.query[restSettings.queryParams.endEventId];
     const payload: DataModels.ProcessModels.ProcessStartRequestPayload = request.body;
     let startCallbackType: DataModels.ProcessModels.StartCallbackType =

--- a/src/endpoints/process_models/process_model_controller.ts
+++ b/src/endpoints/process_models/process_model_controller.ts
@@ -58,7 +58,7 @@ export class ProcessModelController {
 
   public async startProcessInstance(request: HttpRequestWithIdentity, response: Response): Promise<void> {
     const processModelId: string = request.params.process_model_id;
-    const startEventId: string = request.query.start_event_id[restSettings.queryParams.startEventId];
+    const startEventId: string = request.query[restSettings.queryParams.startEventId];
     const endEventId: string = request.query[restSettings.queryParams.endEventId];
     const payload: DataModels.ProcessModels.ProcessStartRequestPayload = request.body;
     let startCallbackType: DataModels.ProcessModels.StartCallbackType =


### PR DESCRIPTION
**Changes:**

1. Retrieve the `start_event_id` parameter from the HTTP request's query parameters, instead of its URL parameters.
This is a breaking change, because the URL of the `startProcessInstance` request has been changed.

**Issues:**

Related: https://github.com/process-engine/process_engine_runtime/issues/252

PR: #33 

## How can others test the changes?

Use the endpoint to start ProcessIntances, without providing a StartEventId.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.).
- [x] I've rebased the `develop` branch with my branch before finishing this PR.
- [x] I've **summarized all changes** in a list above.
- [x] I've mentioned all **PRs, which relate to this one**.
- [x] I've prefixed my Pull Request title is according to [gitmoji guide](https://gitmoji.carloscuesta.me/).
