### PR TITLE
✨Additional notifications for activities

### DIFF
--- a/ioc_module.js
+++ b/ioc_module.js
@@ -1,21 +1,26 @@
 'use strict'
 
+const ActivityEndpoints = require('./dist/commonjs/index').Endpoints.Activity;
+const BoundaryEventEndpoints = require('./dist/commonjs/index').Endpoints.BoundaryEvent;
 const CorrelationEndpoint = require('./dist/commonjs/index').Endpoints.Correlation;
 const EmptyActivityEndpoint = require('./dist/commonjs/index').Endpoints.EmptyActivity;
 const EventEndpoint = require('./dist/commonjs/index').Endpoints.Event;
-const HeatmapEndpoint = require('./dist/commonjs/index').Endpoints.Heatmap;
-const ProcessModelsEndpoint = require('./dist/commonjs/index').Endpoints.ProcessModels;
-const BoundaryEventEndpoints = require('./dist/commonjs/index').Endpoints.BoundaryEvent;
-const IntermediateEventEndpoints = require('./dist/commonjs/index').Endpoints.IntermediateEvent;
-const CallActivityEndpoints = require('./dist/commonjs/index').Endpoints.CallActivity;
 const FlowNodeInstancesEndpoint = require('./dist/commonjs/index').Endpoints.FlowNodeInstances;
-const UserTasksEndpoint = require('./dist/commonjs/index').Endpoints.UserTasks;
+const HeatmapEndpoint = require('./dist/commonjs/index').Endpoints.Heatmap;
+const IntermediateEventEndpoints = require('./dist/commonjs/index').Endpoints.IntermediateEvent;
 const ManualTasksEndpoint = require('./dist/commonjs/index').Endpoints.ManualTasks;
+const ProcessModelsEndpoint = require('./dist/commonjs/index').Endpoints.ProcessModels;
+const UserTasksEndpoint = require('./dist/commonjs/index').Endpoints.UserTasks;
 
 const routerDiscoveryTag = require('@essential-projects/bootstrapper_contracts').routerDiscoveryTag;
 const socketEndpointDiscoveryTag = require('@essential-projects/bootstrapper_contracts').socketEndpointDiscoveryTag;
 
 function registerInContainer(container) {
+  registerHttpEndpoints(container);
+  registerSocketEndpoints(container);
+}
+
+function registerHttpEndpoints(container) {
 
   container.register('ManagementApiCorrelationRouter', CorrelationEndpoint.CorrelationRouter)
     .dependencies('ManagementApiCorrelationController', 'IdentityService')
@@ -35,11 +40,6 @@ function registerInContainer(container) {
     .dependencies('ManagementApiService')
     .singleton();
 
-  container.register('ManagementApiEmptyActivitySocketEndpoint', EmptyActivityEndpoint.EmptyActivitySocketEndpoint)
-    .dependencies('EventAggregator', 'IdentityService', 'ManagementApiService')
-    .singleton()
-    .tags(socketEndpointDiscoveryTag);
-
   container.register('ManagementApiEventRouter', EventEndpoint.EventRouter)
     .dependencies('ManagementApiEventController', 'IdentityService')
     .singleton()
@@ -58,15 +58,19 @@ function registerInContainer(container) {
     .dependencies('ManagementApiService')
     .singleton();
 
+  container.register('ManagementApiManualTaskRouter', ManualTasksEndpoint.ManualTaskRouter)
+    .dependencies('ManagementApiManualTaskController', 'IdentityService')
+    .singleton()
+    .tags(routerDiscoveryTag);
+
+  container.register('ManagementApiManualTaskController', ManualTasksEndpoint.ManualTaskController)
+    .dependencies('ManagementApiService')
+    .singleton();
+
   container.register('ManagementApiProcessModelRouter', ProcessModelsEndpoint.ProcessModelRouter)
     .dependencies('ManagementApiProcessModelController', 'IdentityService')
     .singleton()
     .tags(routerDiscoveryTag);
-
-  container.register('ManagementApiProcessModelSocketEndpoint', ProcessModelsEndpoint.ProcessModelSocketEndpoint)
-    .dependencies('EventAggregator', 'IdentityService')
-    .singleton()
-    .tags(socketEndpointDiscoveryTag);
 
   container.register('ManagementApiProcessModelController', ProcessModelsEndpoint.ProcessModelController)
     .dependencies('ManagementApiService')
@@ -89,8 +93,11 @@ function registerInContainer(container) {
   container.register('ManagementApiUserTaskController', UserTasksEndpoint.UserTaskController)
     .dependencies('ManagementApiService')
     .singleton();
+}
 
-  container.register('ManagementApiUserTaskSocketEndpoint', UserTasksEndpoint.UserTaskSocketEndpoint)
+function registerSocketEndpoints(container) {
+
+  container.register('ManagementApiActivitySocketEndpoint', ActivityEndpoints.ActivitySocketEndpoint)
     .dependencies('EventAggregator', 'IdentityService', 'ManagementApiService')
     .singleton()
     .tags(socketEndpointDiscoveryTag);
@@ -100,26 +107,27 @@ function registerInContainer(container) {
     .singleton()
     .tags(socketEndpointDiscoveryTag);
 
+  container.register('ManagementApiEmptyActivitySocketEndpoint', EmptyActivityEndpoint.EmptyActivitySocketEndpoint)
+    .dependencies('EventAggregator', 'IdentityService', 'ManagementApiService')
+    .singleton()
+    .tags(socketEndpointDiscoveryTag);
+
   container.register('ManagementApiIntermediateEventSocketEndpoint', IntermediateEventEndpoints.IntermediateEventSocketEndpoint)
     .dependencies('EventAggregator', 'IdentityService', 'ManagementApiService')
     .singleton()
     .tags(socketEndpointDiscoveryTag);
 
-  container.register('ManagementApiCallActivitySocketEndpoint', CallActivityEndpoints.CallActivitySocketEndpoint)
+  container.register('ManagementApiManualTaskSocketEndpoint', ManualTasksEndpoint.ManualTaskSocketEndpoint)
     .dependencies('EventAggregator', 'IdentityService', 'ManagementApiService')
     .singleton()
     .tags(socketEndpointDiscoveryTag);
 
-  container.register('ManagementApiManualTaskRouter', ManualTasksEndpoint.ManualTaskRouter)
-    .dependencies('ManagementApiManualTaskController', 'IdentityService')
+  container.register('ManagementApiProcessModelSocketEndpoint', ProcessModelsEndpoint.ProcessModelSocketEndpoint)
+    .dependencies('EventAggregator', 'IdentityService')
     .singleton()
-    .tags(routerDiscoveryTag);
+    .tags(socketEndpointDiscoveryTag);
 
-  container.register('ManagementApiManualTaskController', ManualTasksEndpoint.ManualTaskController)
-    .dependencies('ManagementApiService')
-    .singleton();
-
-  container.register('ManagementApiManualTaskSocketEndpoint', ManualTasksEndpoint.ManualTaskSocketEndpoint)
+  container.register('ManagementApiUserTaskSocketEndpoint', UserTasksEndpoint.UserTaskSocketEndpoint)
     .dependencies('EventAggregator', 'IdentityService', 'ManagementApiService')
     .singleton()
     .tags(socketEndpointDiscoveryTag);

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@essential-projects/http_contracts": "^2.4.0",
     "@essential-projects/http_node": "^4.2.0",
     "@essential-projects/iam_contracts": "^3.5.0",
-    "@process-engine/management_api_contracts": "feature~additional_notifications_for_activities",
+    "@process-engine/management_api_contracts": "10.0.0-fd227177-b16",
     "async-middleware": "^1.2.1",
     "express": "^4.17.0",
     "socket.io": "^2.2.0"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@essential-projects/http_contracts": "^2.4.0",
     "@essential-projects/http_node": "^4.2.0",
     "@essential-projects/iam_contracts": "^3.5.0",
-    "@process-engine/management_api_contracts": "10.0.0-423219a7-b15",
+    "@process-engine/management_api_contracts": "feature~additional_notifications_for_activities",
     "async-middleware": "^1.2.1",
     "express": "^4.17.0",
     "socket.io": "^2.2.0"

--- a/src/endpoints/activity/activity_socket_endpoint.ts
+++ b/src/endpoints/activity/activity_socket_endpoint.ts
@@ -7,7 +7,7 @@ import {IIdentity, IIdentityService} from '@essential-projects/iam_contracts';
 
 import {Messages, socketSettings} from '@process-engine/management_api_contracts';
 
-const logger = Logger.createLogger('management_api:socket.io_endpoint:user_tasks');
+const logger = Logger.createLogger('management_api:socket.io_endpoint:activities');
 
 export class ActivitySocketEndpoint extends BaseSocketEndpoint {
 
@@ -84,8 +84,36 @@ export class ActivitySocketEndpoint extends BaseSocketEndpoint {
         },
       );
 
+    // ---------------------- For backwards compatibility only!
+
+    const callActivityWaitingSubscription =
+      this.eventAggregator.subscribe(
+        Messages.EventAggregatorSettings.messagePaths.callActivityReached,
+        (callActivityWaitingMessage: Messages.SystemEvents.CallActivityReachedMessage): void => {
+
+          logger.warn('"callActivityWaiting" notifications are deprecated. Use "activityReached" instead.');
+
+          socketIoInstance.emit(socketSettings.paths.callActivityWaiting, callActivityWaitingMessage);
+        },
+      );
+
+    const callActivityFinishedSubscription =
+      this.eventAggregator.subscribe(
+        Messages.EventAggregatorSettings.messagePaths.callActivityFinished,
+        (callActivityFinishedMessage: Messages.SystemEvents.CallActivityFinishedMessage): void => {
+
+          logger.warn('"callActivityFinished" notifications are deprecated. Use "activityFinished" instead.');
+
+          socketIoInstance.emit(socketSettings.paths.callActivityFinished, callActivityFinishedMessage);
+        },
+      );
+
+    // ----------------------s
+
     this.endpointSubscriptions.push(activityReachedSubscription);
     this.endpointSubscriptions.push(activityFinishedSubscription);
+    this.endpointSubscriptions.push(callActivityWaitingSubscription);
+    this.endpointSubscriptions.push(callActivityFinishedSubscription);
   }
 
 }

--- a/src/endpoints/activity/activity_socket_endpoint.ts
+++ b/src/endpoints/activity/activity_socket_endpoint.ts
@@ -86,7 +86,7 @@ export class ActivitySocketEndpoint extends BaseSocketEndpoint {
 
     // ---------------------- For backwards compatibility only!
 
-    const callActivityWaitingSubscription =
+    const callActivityReachedSubscription =
       this.eventAggregator.subscribe(
         Messages.EventAggregatorSettings.messagePaths.callActivityReached,
         (callActivityWaitingMessage: Messages.SystemEvents.CallActivityReachedMessage): void => {
@@ -112,7 +112,7 @@ export class ActivitySocketEndpoint extends BaseSocketEndpoint {
 
     this.endpointSubscriptions.push(activityReachedSubscription);
     this.endpointSubscriptions.push(activityFinishedSubscription);
-    this.endpointSubscriptions.push(callActivityWaitingSubscription);
+    this.endpointSubscriptions.push(callActivityReachedSubscription);
     this.endpointSubscriptions.push(callActivityFinishedSubscription);
   }
 

--- a/src/endpoints/activity/activity_socket_endpoint.ts
+++ b/src/endpoints/activity/activity_socket_endpoint.ts
@@ -9,7 +9,7 @@ import {Messages, socketSettings} from '@process-engine/management_api_contracts
 
 const logger = Logger.createLogger('management_api:socket.io_endpoint:user_tasks');
 
-export class CallActivitySocketEndpoint extends BaseSocketEndpoint {
+export class ActivitySocketEndpoint extends BaseSocketEndpoint {
 
   private connections: Map<string, IIdentity> = new Map();
 
@@ -66,35 +66,26 @@ export class CallActivitySocketEndpoint extends BaseSocketEndpoint {
     }
   }
 
-  /**
-   * Creates a number of Subscriptions for globally published events.
-   * These events will be published for every user connected to the socketIO
-   * instance.
-   *
-   * @async
-   * @param socketIoInstance The socketIO instance for which to create the
-   *                         subscriptions.
-   */
   private async createSocketScopeNotifications(socketIoInstance: SocketIO.Namespace): Promise<void> {
 
-    const callActivityReachedSubscription =
+    const activityReachedSubscription =
       this.eventAggregator.subscribe(
-        Messages.EventAggregatorSettings.messagePaths.callActivityReached,
-        (callActivityWaitingMessage: Messages.SystemEvents.CallActivityReachedMessage): void => {
-          socketIoInstance.emit(socketSettings.paths.callActivityWaiting, callActivityWaitingMessage);
+        Messages.EventAggregatorSettings.messagePaths.activityReached,
+        (activityReachedMessage: Messages.SystemEvents.ActivityReachedMessage): void => {
+          socketIoInstance.emit(socketSettings.paths.activityReached, activityReachedMessage);
         },
       );
 
-    const callActivityFinishedSubscription =
+    const activityFinishedSubscription =
       this.eventAggregator.subscribe(
-        Messages.EventAggregatorSettings.messagePaths.callActivityFinished,
-        (callActivityFinishedMessage: Messages.SystemEvents.CallActivityFinishedMessage): void => {
-          socketIoInstance.emit(socketSettings.paths.callActivityFinished, callActivityFinishedMessage);
+        Messages.EventAggregatorSettings.messagePaths.activityFinished,
+        (activityFinishedMessage: Messages.SystemEvents.ActivityFinishedMessage): void => {
+          socketIoInstance.emit(socketSettings.paths.activityFinished, activityFinishedMessage);
         },
       );
 
-    this.endpointSubscriptions.push(callActivityReachedSubscription);
-    this.endpointSubscriptions.push(callActivityFinishedSubscription);
+    this.endpointSubscriptions.push(activityReachedSubscription);
+    this.endpointSubscriptions.push(activityFinishedSubscription);
   }
 
 }

--- a/src/endpoints/activity/index.ts
+++ b/src/endpoints/activity/index.ts
@@ -1,0 +1,1 @@
+export * from './activity_socket_endpoint';

--- a/src/endpoints/call_activity/index.ts
+++ b/src/endpoints/call_activity/index.ts
@@ -1,1 +1,0 @@
-export * from './call_activity_socket_endpoint';

--- a/src/endpoints/index.ts
+++ b/src/endpoints/index.ts
@@ -1,26 +1,26 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
+import * as ActivityEndpoint from './activity/index';
 import * as BoundaryEventEndpoint from './boundary_event/index';
-import * as IntermediateEventEndpoint from './intermediate_event/index';
-import * as CallActivityEndpoint from './call_activity/index';
 import * as CorrelationEndpoint from './correlations/index';
 import * as EmptyActivityEndpoint from './empty_activities/index';
 import * as EventEndpoint from './events/index';
 import * as FlowNodeInstancesEndpoint from './flow_node_instances';
 import * as HeatmapEndpoint from './heatmap/index';
+import * as IntermediateEventEndpoint from './intermediate_event/index';
 import * as ManualTasksEndpoint from './manual_tasks/index';
 import * as ProcessModelEndpoint from './process_models/index';
 import * as UserTaskEndpoint from './user_tasks/index';
 
 export namespace Endpoints {
+  export import Activity = ActivityEndpoint;
+  export import BoundaryEvent = BoundaryEventEndpoint;
   export import Correlation = CorrelationEndpoint;
   export import EmptyActivity = EmptyActivityEndpoint;
   export import Event = EventEndpoint;
-  export import Heatmap = HeatmapEndpoint;
   export import FlowNodeInstances = FlowNodeInstancesEndpoint;
+  export import Heatmap = HeatmapEndpoint;
+  export import IntermediateEvent = IntermediateEventEndpoint;
+  export import ManualTasks = ManualTasksEndpoint;
   export import ProcessModels = ProcessModelEndpoint;
   export import UserTasks = UserTaskEndpoint;
-  export import ManualTasks = ManualTasksEndpoint;
-  export import CallActivity = CallActivityEndpoint;
-  export import BoundaryEvent = BoundaryEventEndpoint;
-  export import IntermediateEvent = IntermediateEventEndpoint;
 }


### PR DESCRIPTION
## Changes

1. Refactor notification subscriptions `onCallActivityWaiting` to `onActivityReached` and `onCallActivityFinished` to `onActivityFinished`.
2. Generalize activity subscription paths, messages and types.
    - This will allow the user to susbcribe to notifications about more than just CallActivities, but also ScriptTasks, SendTasks, ReceiveTasks, ServiceTasks and Subprocesses.
3. Mark `onCallActivityWaiting` and `onCallActivityFinished` as deprecated.
    - The notifications will be removed with the next major release, to give people time to properly adjust their usage of the notifications.

## Issues

Part of https://github.com/process-engine/process_engine_runtime/issues/349

PR: #42

## How to test the changes

- Create Subscriptions for `onActivityReached` and `onActivityFinished`
- The corresponding callbacks will be triggered, when any kind of activity is reached or finished

