### PR TITLE
🔥 Remove CallActivity notifications

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@essential-projects/http_contracts": "^2.4.0",
     "@essential-projects/http_node": "^4.2.0",
     "@essential-projects/iam_contracts": "^3.5.0",
-    "@process-engine/management_api_contracts": "12.1.0-a2da86ab-b30",
+    "@process-engine/management_api_contracts": "feature~remove_on_call_activity_waiting_notification",
     "async-middleware": "^1.2.1",
     "express": "^4.17.0",
     "socket.io": "^2.2.0"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@essential-projects/http_contracts": "^2.4.0",
     "@essential-projects/http_node": "^4.2.0",
     "@essential-projects/iam_contracts": "^3.5.0",
-    "@process-engine/management_api_contracts": "feature~remove_on_call_activity_waiting_notification",
+    "@process-engine/management_api_contracts": "13.0.0-d2eb9786-b32",
     "async-middleware": "^1.2.1",
     "express": "^4.17.0",
     "socket.io": "^2.2.0"

--- a/src/endpoints/notification/notification_socket_endpoint.ts
+++ b/src/endpoints/notification/notification_socket_endpoint.ts
@@ -116,37 +116,9 @@ export class NotificationSocketEndpoint extends BaseSocketEndpoint {
         },
       );
 
-    // ---------------------- For backwards compatibility only!
-
-    const callActivityReachedSubscription =
-      this.eventAggregator.subscribe(
-        Messages.EventAggregatorSettings.messagePaths.callActivityReached,
-        (callActivityWaitingMessage: Messages.SystemEvents.CallActivityReachedMessage): void => {
-
-          logger.warn('"callActivityWaiting" notifications are deprecated. Use "activityReached" instead.');
-
-          socketIoInstance.emit(socketSettings.paths.callActivityWaiting, callActivityWaitingMessage);
-        },
-      );
-
-    const callActivityFinishedSubscription =
-      this.eventAggregator.subscribe(
-        Messages.EventAggregatorSettings.messagePaths.callActivityFinished,
-        (callActivityFinishedMessage: Messages.SystemEvents.CallActivityFinishedMessage): void => {
-
-          logger.warn('"callActivityFinished" notifications are deprecated. Use "activityFinished" instead.');
-
-          socketIoInstance.emit(socketSettings.paths.callActivityFinished, callActivityFinishedMessage);
-        },
-      );
-
-    // ----------------------s
-
     this.endpointSubscriptions.push(activityReachedSubscription);
     this.endpointSubscriptions.push(activityFinishedSubscription);
     this.endpointSubscriptions.push(boundaryEventTriggeredSubscription);
-    this.endpointSubscriptions.push(callActivityReachedSubscription);
-    this.endpointSubscriptions.push(callActivityFinishedSubscription);
     this.endpointSubscriptions.push(intermediateThrowEventTriggeredSubscription);
     this.endpointSubscriptions.push(intermediateCatchEventReachedSubscription);
     this.endpointSubscriptions.push(intermediateCatchEventFinishedSubscription);


### PR DESCRIPTION
## Changes

1. Remove all the deprecated `CallActivity` notifications

## Issues

PR: #52