### PR TITLE
✨ Add Queries for retrieving ProcessInstances

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/management_api_http",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "description": "HTTP endpoint implementation for the process-engine.io Management APIs",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@essential-projects/http_contracts": "^2.4.0",
     "@essential-projects/http_node": "^4.2.0",
     "@essential-projects/iam_contracts": "^3.5.0",
-    "@process-engine/management_api_contracts": "13.0.0-alpha.1",
+    "@process-engine/management_api_contracts": "feature~flatten_correlation_types",
     "async-middleware": "^1.2.1",
     "express": "^4.17.0",
     "socket.io": "^2.2.0"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@essential-projects/http_contracts": "^2.4.0",
     "@essential-projects/http_node": "^4.2.0",
     "@essential-projects/iam_contracts": "^3.5.0",
-    "@process-engine/management_api_contracts": "feature~flatten_correlation_types",
+    "@process-engine/management_api_contracts": "14.0.0-alpha.1",
     "async-middleware": "^1.2.1",
     "express": "^4.17.0",
     "socket.io": "^2.2.0"

--- a/src/endpoints/correlation/correlation_controller.ts
+++ b/src/endpoints/correlation/correlation_controller.ts
@@ -1,6 +1,6 @@
 import {HttpRequestWithIdentity} from '@essential-projects/http_contracts';
 
-import {APIs, HttpController} from '@process-engine/management_api_contracts';
+import {APIs, DataModels, HttpController} from '@process-engine/management_api_contracts';
 
 import {Response} from 'express';
 
@@ -59,6 +59,39 @@ export class CorrelationController implements HttpController.ICorrelationHttpCon
     const identity = request.identity;
 
     const result = await this.correlationService.getProcessInstanceById(identity, processInstanceId);
+
+    response.status(this.httpCodeSuccessfulResponse).json(result);
+  }
+
+  public async getProcessInstancesForCorrelation(request: HttpRequestWithIdentity, response: Response): Promise<void> {
+    const correlationId = request.params.correlation_id;
+    const identity = request.identity;
+    const offset = request.query.offset || 0;
+    const limit = request.query.limit || 0;
+
+    const result = await this.correlationService.getProcessInstancesForCorrelation(identity, correlationId, offset, limit);
+
+    response.status(this.httpCodeSuccessfulResponse).json(result);
+  }
+
+  public async getProcessInstancesForProcessModel(request: HttpRequestWithIdentity, response: Response): Promise<void> {
+    const processModelId = request.params.process_model_id;
+    const identity = request.identity;
+    const offset = request.query.offset || 0;
+    const limit = request.query.limit || 0;
+
+    const result = await this.correlationService.getProcessInstancesForProcessModel(identity, processModelId, offset, limit);
+
+    response.status(this.httpCodeSuccessfulResponse).json(result);
+  }
+
+  public async getProcessInstancesByState(request: HttpRequestWithIdentity, response: Response): Promise<void> {
+    const state = DataModels.Correlations.CorrelationState[request.params.process_instance_state];
+    const identity = request.identity;
+    const offset = request.query.offset || 0;
+    const limit = request.query.limit || 0;
+
+    const result = await this.correlationService.getProcessInstancesByState(identity, state, offset, limit);
 
     response.status(this.httpCodeSuccessfulResponse).json(result);
   }

--- a/src/endpoints/correlation/correlation_controller.ts
+++ b/src/endpoints/correlation/correlation_controller.ts
@@ -43,15 +43,6 @@ export class CorrelationController implements HttpController.ICorrelationHttpCon
     response.status(this.httpCodeSuccessfulResponse).json(result);
   }
 
-  public async getCorrelationByProcessInstanceId(request: HttpRequestWithIdentity, response: Response): Promise<void> {
-    const processInstanceId = request.params.process_instance_id;
-    const identity = request.identity;
-
-    const result = await this.correlationService.getCorrelationByProcessInstanceId(identity, processInstanceId);
-
-    response.status(this.httpCodeSuccessfulResponse).json(result);
-  }
-
   public async getCorrelationsByProcessModelId(request: HttpRequestWithIdentity, response: Response): Promise<void> {
     const processModelId = request.params.process_model_id;
     const identity = request.identity;
@@ -59,6 +50,15 @@ export class CorrelationController implements HttpController.ICorrelationHttpCon
     const limit = request.query.limit || 0;
 
     const result = await this.correlationService.getCorrelationsByProcessModelId(identity, processModelId, offset, limit);
+
+    response.status(this.httpCodeSuccessfulResponse).json(result);
+  }
+
+  public async getProcessInstanceById(request: HttpRequestWithIdentity, response: Response): Promise<void> {
+    const processInstanceId = request.params.process_instance_id;
+    const identity = request.identity;
+
+    const result = await this.correlationService.getProcessInstanceById(identity, processInstanceId);
 
     response.status(this.httpCodeSuccessfulResponse).json(result);
   }

--- a/src/endpoints/correlation/correlation_router.ts
+++ b/src/endpoints/correlation/correlation_router.ts
@@ -38,7 +38,7 @@ export class CorrelationRouter extends BaseRouter {
 
     this.router.get(restSettings.paths.getAllCorrelations, wrap(controller.getAllCorrelations.bind(controller)));
     this.router.get(restSettings.paths.getActiveCorrelations, wrap(controller.getActiveCorrelations.bind(controller)));
-    this.router.get(restSettings.paths.getCorrelationByProcessInstanceId, wrap(controller.getCorrelationByProcessInstanceId.bind(controller)));
+    this.router.get(restSettings.paths.getProcessInstanceById, wrap(controller.getProcessInstanceById.bind(controller)));
     this.router.get(restSettings.paths.getCorrelationsByProcessModelId, wrap(controller.getCorrelationsByProcessModelId.bind(controller)));
     this.router.get(restSettings.paths.getCorrelationById, wrap(controller.getCorrelationById.bind(controller)));
   }

--- a/src/endpoints/correlation/correlation_router.ts
+++ b/src/endpoints/correlation/correlation_router.ts
@@ -38,9 +38,12 @@ export class CorrelationRouter extends BaseRouter {
 
     this.router.get(restSettings.paths.getAllCorrelations, wrap(controller.getAllCorrelations.bind(controller)));
     this.router.get(restSettings.paths.getActiveCorrelations, wrap(controller.getActiveCorrelations.bind(controller)));
-    this.router.get(restSettings.paths.getProcessInstanceById, wrap(controller.getProcessInstanceById.bind(controller)));
-    this.router.get(restSettings.paths.getCorrelationsByProcessModelId, wrap(controller.getCorrelationsByProcessModelId.bind(controller)));
     this.router.get(restSettings.paths.getCorrelationById, wrap(controller.getCorrelationById.bind(controller)));
+    this.router.get(restSettings.paths.getCorrelationsByProcessModelId, wrap(controller.getCorrelationsByProcessModelId.bind(controller)));
+    this.router.get(restSettings.paths.getProcessInstanceById, wrap(controller.getProcessInstanceById.bind(controller)));
+    this.router.get(restSettings.paths.getProcessInstancesForCorrelation, wrap(controller.getProcessInstancesForCorrelation.bind(controller)));
+    this.router.get(restSettings.paths.getProcessInstancesForProcessModel, wrap(controller.getProcessInstancesForProcessModel.bind(controller)));
+    this.router.get(restSettings.paths.getProcessInstancesByState, wrap(controller.getProcessInstancesByState.bind(controller)));
   }
 
 }


### PR DESCRIPTION
## Changes

1. Rename `getCorrelationByProcessInstanceId` to `getProcessInstanceById`
2. Add UseCases for getting ProcessInstances:
    - getProcessInstancesForCorrelation
    - getProcessInstancesForProcessModel
    - getProcessInstancesByState

## Issues

Part of https://github.com/process-engine/process_engine_runtime/issues/404

PR: #58